### PR TITLE
Fix typo in network configuration file path

### DIFF
--- a/src/constants/globalConfig.ts
+++ b/src/constants/globalConfig.ts
@@ -42,7 +42,7 @@ const globalConfig: GlobalConfig = {
         RECEIPT: {
             timeout: 0,
             confirmations: 2,
-            //todo: for localhost chain this needs to be set to 1. Mainnet chains need their per-chain confirmations found in conceroNetowrks.ts
+            //todo: for localhost chain this needs to be set to 1. Mainnet chains need their per-chain confirmations found in conceroNetworks.ts
         },
         WRITE_CONTRACT: {
             gas: 3000000n,


### PR DESCRIPTION
Updates the comment reference from 'conceroNetowrks.ts' to 'conceroNetworks.ts' to fix a typo in the file path mentioned in globalConfig.ts.

Changes:
- Corrected misspelling in the comment referencing the networks configuration file